### PR TITLE
Feature/tabs split diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# go-split-money
-Quick Go demo for splitting money with a predetermined difference.
+<h1>go-split-money</h1>
+
+An example project that holds a ```go get```able package to split a tab into shares.
+
+<h2>Table of Contents</h2>
+
+- [Package List](#package-list)
+    - [tabs](#tabs)
+
+
+# tabs
+## GoDoc
+For documentation, see [GoDoc](https://godoc.org/github.com/RainbowKatz/go-split-money/tabs)
+
+## How to Run
+The ```main.go``` file is set to run ```SplitDiffPrint```, a convenience func which calls the ```SplitDiff``` function, and then displays the formatted results.
+
+To run with default values (from repo root):
+```
+$ go run main.go
+```
+output:
+```
+SplitDiff(tab=10.000000, shares=2, diff=1.000000) >>
+  Share 1: $4.50
+  Share 2: $5.50
+```
+
+To run with custom values, use command-line flags:
+
+```
+$ go run main.go -tab=28.00 -shares=5 -diff=2.00
+
+SplitDiff(tab=28.000000, shares=5, diff=2.000000) >>
+  Share 1: $1.60
+  Share 2: $3.60
+  Share 3: $5.60
+  Share 4: $7.60
+  Share 5: $9.60
+```
+
+Testing a case with rounding error (taken from [test cases](./tabs/splitdiff_test.go))
+```
+$ go run main.go -tab=7 -shares=2 -diff=2.33
+
+SplitDiff(tab=7.000000, shares=2, diff=2.330000) >>
+  Share 1: $2.34
+  Share 2: $4.67
+
+Error: Results not exact due to rounding to nearest cent
+exit status 1
+```

--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ SplitDiff(tab=7.000000, shares=2, diff=2.330000) >>
 Error: Results not exact due to rounding to nearest cent
 exit status 1
 ```
+
+## How to Test
+To run [tests](./tabs/splitdiff_test.go) (from repo root):
+```
+$ go test ./tabs
+ok      github.com/RainbowKatz/go-split-money/tabs      0.346s
+```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ An example project that holds a ```go get```able package to split a tab into sha
 
 <h2>Table of Contents</h2>
 
-- [Package List](#package-list)
-    - [tabs](#tabs)
+- [tabs](#tabs)
+    - [GoDoc](#godoc)
+    - [How to Run](#how-to-run)
+    - [How to Test](#how-to-test)
 
 
 # tabs

--- a/main.go
+++ b/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/RainbowKatz/go-split-money/tabs"
+)
+
+func main() {
+	// tabs.SplitDiff command-line flags (defaults to tab=10, shares=2, diff=1)
+	tab := flag.Float64("tab", 10.00, "Total amount to split into shares")
+	shares := flag.Int("shares", 2, "Number of shares to split tab into")
+	diff := flag.Float64("diff", 1.00, "Difference between consecutive shares")
+	flag.Parse()
+
+	// call tabs.SplitDiffPrint, which calls SplitDiff and prints results
+	_, err := tabs.SplitDiffPrint(*tab, *shares, *diff)
+	if err != nil {
+		fmt.Printf("\nError: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/tabs/splitdiff.go
+++ b/tabs/splitdiff.go
@@ -1,0 +1,100 @@
+/*
+	Package Tabs provides methods of splitting a typical tab between multiple parties.
+*/
+package tabs
+
+import (
+	"fmt"
+	"math"
+)
+
+const stdErr float64 = 0.009
+
+// SplitDiffPrint calls SplitDiff and then prints the results
+func SplitDiffPrint(tab float64, shares int, diff float64) ([]float64, error) {
+	results, err := SplitDiff(tab, shares, diff)
+	if err != nil && results == nil {
+		return nil, err
+	}
+
+	//display results
+	fmt.Printf("\nSplitDiff(tab=%f, shares=%d, diff=%f) >>\n", tab, shares, diff)
+	for i, share := range results {
+		fmt.Printf("  Share %d: $%.2f\n", i+1, share)
+	}
+
+	// return results
+	return results, err
+}
+
+// SplitDiff splits a tab into a given number of shares, with a diff between each consecutive share.
+// SplitDiff may return results along with an error if rounding error(s) occurred.
+func SplitDiff(tab float64, shares int, diff float64) ([]float64, error) {
+	// output
+	var splitTabs []float64
+	var shareTotal float64
+
+	// validate
+	if err := validateSplitDiff(tab, shares, diff); err != nil {
+		return nil, err
+	}
+
+	// calculate first/lowest share
+	var lowestShare float64
+	if shares%2 == 0 {
+		lowestShare = tab/float64(shares) - (diff/float64(2))*(2*float64(shares/2)-1)
+	} else {
+		lowestShare = tab/float64(shares) - float64(shares/2)*diff
+	}
+
+	for w, currentShare := 0, 0.; w < shares; w++ {
+		currentShare = lowestShare + float64(w)*diff
+
+		// rount to nearest penny
+		currentShare = math.Round(currentShare/0.01) * 0.01
+		splitTabs = append(splitTabs, currentShare)
+		shareTotal += currentShare
+	}
+
+	// if split not possible due to rounding to nearest cent, return results anyway along with error
+	if math.Abs(shareTotal-tab) >= stdErr {
+		return splitTabs, fmt.Errorf("Results not exact due to rounding to nearest cent")
+	}
+
+	// return output with no error
+	return splitTabs, nil
+}
+
+// validateSplitDiff performs validation for the SplitDiff function
+func validateSplitDiff(tab float64, shares int, diff float64) error {
+	// validate total, must be positive
+	if tab <= 0. {
+		return fmt.Errorf("tab must be positive")
+	}
+
+	// validate shares is at least 2
+	if shares < 2 {
+		return fmt.Errorf("shares must be at least 2")
+	}
+
+	// validate diff, must be non-negative
+	if diff < 0. {
+		return fmt.Errorf("diff must be non-negative")
+	}
+
+	// calculate the minLargestShare, minimum largest share to satisfy the diff and number of shares
+	//   i.e. 4 shares and diff of 2 means minLargestShare of 6 >> 0, 2, 4, 6
+	minLargestShare := float64(shares-1) * diff
+
+	// calculate minTab, that is the minimum tab to perform the split given the diffs
+	minTab := float64(shares/2) * minLargestShare
+	// 1st term is 0, last is minLargestShare, formula @ http://www.mathwords.com/a/arithmetic_series.htm
+
+	// validate input tab is not less than minTab
+	if tab < minTab {
+		return fmt.Errorf("cannot split tab %f into %d tabs with a diff of %f between each tab", tab, shares, diff)
+	}
+
+	// validated
+	return nil
+}

--- a/tabs/splitdiff_test.go
+++ b/tabs/splitdiff_test.go
@@ -1,0 +1,78 @@
+package tabs_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/RainbowKatz/go-split-money/tabs"
+)
+
+const stdErr float64 = 0.01
+
+var (
+	// these test cases will complete sucessfully, though some will have rounding errors
+	positiveTestCases = []struct {
+		tab             float64   // tab total to split
+		shares          int       // number of shares to split the tab into
+		diff            float64   // difference between consecutive shares
+		expectedResults []float64 // expected result shares
+		isExpectedErr   bool      // boolean that is true only if error expected
+	}{
+		{10., 2, 1., []float64{4.5, 5.5}, false},
+		{10., 4, 0., []float64{2.5, 2.5, 2.5, 2.5}, false},
+		{111., 3, 18., []float64{19., 37., 55.}, false},
+		{220., 4, 20., []float64{25., 45., 65., 85.}, false},
+		{17., 7, 0.18, []float64{1.89, 2.07, 2.25, 2.43, 2.61, 2.79, 2.97}, true}, // rounding error
+		{7., 2, 2.33, []float64{2.34, 4.67}, true},                                // rounding error
+		{22., 3, 5., []float64{2.33, 7.33, 12.33}, true},                          // rounding error
+		{12., 4, 1.11, []float64{1.34, 2.45, 3.56, 4.67}, true},                   // rounding error
+	}
+
+	// these test cases will result in errors for various validation reasons (not rounding errors)
+	negativeTestCases = []struct {
+		tab    float64 // tab total to split
+		shares int     // number of shares to split the tab into
+		diff   float64 // difference between consecutive shares
+	}{
+		{10., 1, 1.},    // min shares
+		{10., 0, 1.},    // min shares
+		{-2., 4, 20.},   // positive tab
+		{0., 4, 20.},    // positive tab
+		{20., 4, -0.05}, // non-negative diff
+		{10., 2, 11.},   // minTab
+		{111., 13, 18.}, // minTab
+	}
+)
+
+func TestSplitDiffPositiveFlows(t *testing.T) {
+	for _, tt := range positiveTestCases {
+		actualResults, err := tabs.SplitDiff(tt.tab, tt.shares, tt.diff)
+		if err == nil && tt.isExpectedErr {
+			t.Errorf("Error incorrect, got: nil, expected: err")
+			break
+		}
+		if err != nil && !tt.isExpectedErr {
+			t.Errorf("Error incorrect, got: err, expected: nil")
+			break
+		}
+
+		// compare results
+		for caseIdx := 0; caseIdx < len(tt.expectedResults); caseIdx++ {
+			// wrong if off by a stdErr or more
+			if math.Abs(actualResults[caseIdx]-tt.expectedResults[caseIdx]) >= stdErr {
+				t.Errorf("Results incorrect, got: %v, expected: %v >> case %d: {%.2f, %d, %.2f}", actualResults, tt.expectedResults, caseIdx, tt.tab, tt.shares, tt.diff)
+				break
+			}
+		}
+	}
+}
+
+func TestSplitDiffNegativeFlows(t *testing.T) {
+	for caseIdx, tt := range negativeTestCases {
+		_, err := tabs.SplitDiff(tt.tab, tt.shares, tt.diff)
+		if err == nil {
+			t.Errorf("Error incorrect, got: nil, expected: err >> case %d: {%.2f, %d, %.2f}", caseIdx, tt.tab, tt.shares, tt.diff)
+			break
+		}
+	}
+}


### PR DESCRIPTION
Add initial versions of ```tabs``` package with ```SplitDiff``` function, wrapped by ```SplitDiffPrint```.  A ```main.go``` was provided with command-line flags for quick testing on the fly.